### PR TITLE
cleanup requires

### DIFF
--- a/lib/backstop.rb
+++ b/lib/backstop.rb
@@ -1,4 +1,6 @@
 require 'socket'
 require 'uri'
 
+require 'backstop/config'
+require 'backstop/collectd/parser'
 require 'backstop/publisher'

--- a/lib/backstop/web.rb
+++ b/lib/backstop/web.rb
@@ -1,10 +1,7 @@
 require 'sinatra'
-require 'socket'
 require 'json'
 
-require 'backstop/publisher'
-require 'backstop/config'
-require 'backstop/collectd/parser'
+require 'backstop'
 
 module Backstop
   class Application < Sinatra::Base


### PR DESCRIPTION
`web` should just load `backstop` instead of the individual libs.
