### PR TITLE
Dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+docker-compose.yml
+Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.3
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/
+RUN bundle install
+
+COPY . /usr/src/app
+
+EXPOSE 3000
+CMD ["rackup", "-o", "0.0.0.0", "-p", "3000", "-s", "thin" ]


### PR DESCRIPTION
This commit adds two files needed to build a Docker image of the service.

To run the build, use ``` docker build -t backstop . ```

Resulting Docker image exposes (and listens to) port 3000.